### PR TITLE
ignore unexported fields

### DIFF
--- a/flagset.go
+++ b/flagset.go
@@ -62,6 +62,10 @@ func (f *FlagSetFiller) walkFields(flagSet *flag.FlagSet, prefix string,
 		field := structType.Field(i)
 		fieldValue := structVal.Field(i)
 
+		if !fieldValue.CanSet() {
+			continue
+		}
+
 		switch field.Type.Kind() {
 		case reflect.Struct:
 			err := f.walkFields(flagSet, prefix+field.Name, fieldValue, field.Type)


### PR DESCRIPTION
I was having trouble with Fill wiping out un-exported fields in my struct. This fix ignores un-exported fields so that they stay in tact on the input struct.