### PR TITLE
Keep nested pointers

### DIFF
--- a/flagset.go
+++ b/flagset.go
@@ -62,6 +62,10 @@ func (f *FlagSetFiller) walkFields(flagSet *flag.FlagSet, prefix string,
 		field := structType.Field(i)
 		fieldValue := structVal.Field(i)
 
+		if !fieldValue.CanSet() {
+			continue
+		}
+
 		switch field.Type.Kind() {
 		case reflect.Struct:
 			err := f.walkFields(flagSet, prefix+field.Name, fieldValue, field.Type)

--- a/flagset.go
+++ b/flagset.go
@@ -62,10 +62,6 @@ func (f *FlagSetFiller) walkFields(flagSet *flag.FlagSet, prefix string,
 		field := structType.Field(i)
 		fieldValue := structVal.Field(i)
 
-		if !fieldValue.CanSet() {
-			continue
-		}
-
 		switch field.Type.Kind() {
 		case reflect.Struct:
 			err := f.walkFields(flagSet, prefix+field.Name, fieldValue, field.Type)
@@ -75,8 +71,10 @@ func (f *FlagSetFiller) walkFields(flagSet *flag.FlagSet, prefix string,
 
 		case reflect.Ptr:
 			if fieldValue.CanSet() && field.Type.Elem().Kind() == reflect.Struct {
-				// fill the pointer with a new struct of their type
-				fieldValue.Set(reflect.New(field.Type.Elem()))
+				// fill the pointer with a new struct of their type if it is nil
+				if fieldValue.IsNil() {
+					fieldValue.Set(reflect.New(field.Type.Elem()))
+				}
 
 				err := f.walkFields(flagSet, field.Name, fieldValue.Elem(), field.Type.Elem())
 				if err != nil {

--- a/flagset.go
+++ b/flagset.go
@@ -103,8 +103,11 @@ func (f *FlagSetFiller) processField(flagSet *flag.FlagSet, fieldRef interface{}
 	var envName string
 	if override, exists := tag.Lookup("env"); exists {
 		envName = override
-	} else if f.options.envRenamer != nil {
-		envName = f.options.envRenamer(name)
+	} else if len(f.options.envRenamer) > 0 {
+		envName = name
+		for _, renamer := range f.options.envRenamer {
+			envName = renamer(envName)
+		}
 	}
 
 	usage := requoteUsage(tag.Get("usage"))

--- a/flagset_test.go
+++ b/flagset_test.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	"os"
+	"testing"
+	"time"
+
 	"github.com/iancoleman/strcase"
 	"github.com/itzg/go-flagsfiller"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"os"
-	"testing"
-	"time"
 )
 
 func TestStringFields(t *testing.T) {
@@ -289,16 +290,25 @@ func TestNumbers(t *testing.T) {
 }
 
 func TestDefaultsViaLiteral(t *testing.T) {
+	type Nested struct {
+		Exported   string
+		unExported string
+	}
 	type Config struct {
 		Host    string
 		Enabled bool
 		Timeout time.Duration
+		Nested  *Nested
 	}
 
 	var config = Config{
 		Host:    "h1",
 		Enabled: true,
 		Timeout: 5 * time.Second,
+		Nested: &Nested{
+			Exported:   "exported",
+			unExported: "un-exported",
+		},
 	}
 
 	filler := flagsfiller.New()
@@ -309,11 +319,15 @@ func TestDefaultsViaLiteral(t *testing.T) {
 
 	buf := grabUsage(flagset)
 
+	assert.Equal(t, "un-exported", config.Nested.unExported)
+
 	assert.Equal(t, `
   -enabled
     	 (default true)
   -host string
     	 (default "h1")
+  -nested-exported string
+    	 (default "exported")
   -timeout duration
     	 (default 5s)
 `, buf.String())

--- a/options.go
+++ b/options.go
@@ -13,15 +13,15 @@ var DefaultFieldRenamer = KebabRenamer()
 type FillerOption func(opt *fillerOptions)
 
 type fillerOptions struct {
-	fieldRenamer Renamer
-	envRenamer   Renamer
+	fieldRenamer []Renamer
+	envRenamer   []Renamer
 }
 
 // WithFieldRenamer declares an option to customize the Renamer used to convert field names
 // to flag names.
 func WithFieldRenamer(renamer Renamer) FillerOption {
 	return func(opt *fillerOptions) {
-		opt.fieldRenamer = renamer
+		opt.fieldRenamer = append(opt.fieldRenamer, renamer)
 	}
 }
 
@@ -37,15 +37,18 @@ func WithEnv(prefix string) FillerOption {
 // are mapped to environment variable names by applying the given Renamer
 func WithEnvRenamer(renamer Renamer) FillerOption {
 	return func(opt *fillerOptions) {
-		opt.envRenamer = renamer
+		opt.envRenamer = append(opt.envRenamer, renamer)
 	}
 }
 
 func (o *fillerOptions) renameLongName(name string) string {
-	if o.fieldRenamer == nil {
+	if len(o.fieldRenamer) == 0 {
 		return DefaultFieldRenamer(name)
 	} else {
-		return o.fieldRenamer(name)
+		for _, renamer := range o.fieldRenamer {
+			name = renamer(name)
+		}
+		return name
 	}
 }
 


### PR DESCRIPTION
Currently if a nested pointer struct has a value it is discarded and replaced with an empty struct. This keeps the original struct if the pointer is not nil.

I also made the re-namers slices to allow for multiple renamers.