### PR TITLE
added option for not setting values from env variables

### DIFF
--- a/flagset.go
+++ b/flagset.go
@@ -178,7 +178,7 @@ func (f *FlagSetFiller) processField(flagSet *flag.FlagSet, fieldRef interface{}
 		return err
 	}
 
-	if envName != "" {
+	if !f.options.noSetFromEnv && envName != "" {
 		if val, exists := os.LookupEnv(envName); exists {
 			err := flagSet.Lookup(renamed).Value.Set(val)
 			if err != nil {

--- a/flagset_test.go
+++ b/flagset_test.go
@@ -772,6 +772,34 @@ func TestWithEnvOverrideDisable(t *testing.T) {
 `, buf.String())
 }
 
+func TestNoSetFromEnv(t *testing.T) {
+	type Config struct {
+		Host string `usage:"arg only"`
+	}
+
+	var config Config
+
+	assert.NoError(t, os.Setenv("APP_HOST", "host from env"))
+
+	filler := flagsfiller.New(
+		flagsfiller.WithEnv("App"),
+		flagsfiller.NoSetFromEnv(),
+	)
+
+	var flagset flag.FlagSet
+	err := filler.Fill(&flagset, &config)
+	require.NoError(t, err)
+
+	buf := grabUsage(flagset)
+
+	assert.Empty(t, config.Host)
+
+	assert.Equal(t, `
+  -host string
+    	arg only (env APP_HOST)
+`, buf.String())
+}
+
 func TestFlagNameOverride(t *testing.T) {
 	type Config struct {
 		Host        string `flag:"server_address" usage:"address of server"`

--- a/options.go
+++ b/options.go
@@ -15,6 +15,7 @@ type FillerOption func(opt *fillerOptions)
 type fillerOptions struct {
 	fieldRenamer []Renamer
 	envRenamer   []Renamer
+	noSetFromEnv bool
 }
 
 // WithFieldRenamer declares an option to customize the Renamer used to convert field names
@@ -38,6 +39,15 @@ func WithEnv(prefix string) FillerOption {
 func WithEnvRenamer(renamer Renamer) FillerOption {
 	return func(opt *fillerOptions) {
 		opt.envRenamer = append(opt.envRenamer, renamer)
+	}
+}
+
+// NoSetFromEnv ignores setting values from the environment.
+// All environment variable renamers are run but values are not set from the environment.
+// This is good to use if you need to build a flag set with default values that don't consider the current environment.
+func NoSetFromEnv() FillerOption {
+	return func(opt *fillerOptions) {
+		opt.noSetFromEnv = true
 	}
 }
 


### PR DESCRIPTION
This will allow you to process env variables without actually setting values from them.
This is useful if you want to get usage without considering the current environment in the default values.