### PR TITLE
ignore children of ignored field

### DIFF
--- a/flagset.go
+++ b/flagset.go
@@ -65,6 +65,12 @@ func (f *FlagSetFiller) walkFields(flagSet *flag.FlagSet, prefix string,
 		field := structType.Field(i)
 		fieldValue := structVal.Field(i)
 
+		if flagTag, ok := field.Tag.Lookup("flag"); ok {
+			if flagTag == "" {
+				continue
+			}
+		}
+
 		switch field.Type.Kind() {
 		case reflect.Struct:
 			err := f.walkFields(flagSet, prefix+field.Name, fieldValue, field.Type)


### PR DESCRIPTION
This will ignore the children of an ignored field.

Currently if a field is ignored, the fields nested under it are still processed.