### PR TITLE
- add support for types with encoding.TextUnmarshaler

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,10 @@ import "github.com/itzg/go-flagsfiller"
 	- `net.IP` parse via net.ParseIP()
 	- `net.IPNet` parse via net.ParseCIDR()
 	- `net.HardwareAddr` parse via net.ParseMAC()
+	- and all types that implement encoding.TextUnmarshaler interface
 - Optionally set flag values from environment variables. Similar to flag names, environment variable names are derived automatically from the field names
 - New types could be supported via user code, via `RegisterSimpleType(ConvertFunc)`, check [time.go](time.go) and [net.go](net.go) to see how it works
+	- note: in case of a registered type also implements encoding.TextUnmarshaler, then registered type's ConvertFunc is preferred 
 
 ## Quick example
 

--- a/general.go
+++ b/general.go
@@ -31,7 +31,6 @@ func processGeneral[T any](fieldRef interface{}, val flagVal[T],
 	hasDefaultTag bool, tagDefault string,
 	flagSet *flag.FlagSet, renamed string,
 	usage string, aliases string) (err error) {
-
 	casted := fieldRef.(*T)
 	if hasDefaultTag {
 		*casted, err = val.StrConverter(tagDefault)

--- a/simple.go
+++ b/simple.go
@@ -32,7 +32,7 @@ func (v *simpleType[T]) String() string {
 	if v.val == nil {
 		return fmt.Sprint(nil)
 	}
-	return fmt.Sprintf("%v", *v.val)
+	return fmt.Sprint(v.val)
 }
 
 func (v *simpleType[T]) StrConverter(s string) (T, error) {

--- a/txtunmarshaler.go
+++ b/txtunmarshaler.go
@@ -1,0 +1,60 @@
+// This file implements support for all types that support interface encoding.TextUnmarshaler
+package flagsfiller
+
+import (
+	"encoding"
+	"flag"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// RegisterTextUnmarshaler use is optional, since flagsfiller will automatically register the types implement encoding.TextUnmarshaler it encounters
+func RegisterTextUnmarshaler(in any) {
+	base := textUnmarshalerType{}
+	extendedTypes[getTypeName(reflect.TypeOf(in).Elem())] = base.process
+}
+
+type textUnmarshalerType struct {
+	val encoding.TextUnmarshaler
+}
+
+// String implements flag.Value interface
+func (tv *textUnmarshalerType) String() string {
+	if tv.val == nil {
+		return fmt.Sprint(nil)
+	}
+	return fmt.Sprint(tv.val)
+}
+
+// Set implements flag.Value interface
+func (tv *textUnmarshalerType) Set(s string) error {
+	return tv.val.UnmarshalText([]byte(s))
+}
+
+func (tv *textUnmarshalerType) process(tag reflect.StructTag, fieldRef interface{},
+	hasDefaultTag bool, tagDefault string,
+	flagSet *flag.FlagSet, renamed string,
+	usage string, aliases string) error {
+	v, ok := fieldRef.(encoding.TextUnmarshaler)
+	if !ok {
+		return fmt.Errorf("can't cast %v into encoding.TextUnmarshaler", fieldRef)
+	}
+	newval := textUnmarshalerType{
+		val: v,
+	}
+	if hasDefaultTag {
+		err := newval.Set(tagDefault)
+		if err != nil {
+			return fmt.Errorf("failed to parse default value into %v: %w", reflect.TypeOf(fieldRef), err)
+		}
+	}
+	flagSet.Var(&newval, renamed, usage)
+	if aliases != "" {
+		for _, alias := range strings.Split(aliases, ",") {
+			flagSet.Var(&newval, alias, usage)
+		}
+	}
+	return nil
+
+}


### PR DESCRIPTION
This PR add support for the types implements `encoding.TextUnmarshaler` interface, apparently there are some types in standard lib does that like `netip.Addr`. 
Unlike the simplyType, This support doesn't require any user code by default; however if a registered simpleType also implements `encoding.TextUnmarshaler` (like time.Time), then register convert function will be used. 

This PR also fixes an issue with simpletype.String()