### PR TITLE
Allow slice and map fields to accept newline delimited values

### DIFF
--- a/docs.go
+++ b/docs.go
@@ -110,7 +110,7 @@ converted into the field's type. For example,
 
 FlagSetFiller also includes support for []string fields.
 Repetition of the argument appends to the slice and/or an argument value can contain a
-comma-separated list of values.
+comma or newline separated list of values.
 
 For example:
 
@@ -126,7 +126,7 @@ The default tag's value is provided as a comma-separated list, such as
 
 FlagSetFiller also includes support for map[string]string fields.
 Each argument entry is a key=value and/or repetition of the arguments adds to the map or
-multiple entries can be comma-separated in a single argument value.
+multiple entries can be comma or newline separated in a single argument value.
 
 For example:
 

--- a/flagset.go
+++ b/flagset.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -658,7 +659,8 @@ func (s *strSliceVar) Set(val string) error {
 }
 
 func parseStringSlice(val string) []string {
-	return strings.Split(val, ",")
+	splitter := regexp.MustCompile("[\n,]")
+	return splitter.Split(val, -1)
 }
 
 type strToStrMapVar struct {
@@ -696,7 +698,9 @@ func (s strToStrMapVar) Set(val string) error {
 func parseStringToStringMap(val string) map[string]string {
 	result := make(map[string]string)
 
-	pairs := strings.Split(val, ",")
+	splitter := regexp.MustCompile("[\n,]")
+
+	pairs := splitter.Split(val, -1)
 	for _, pair := range pairs {
 		kv := strings.SplitN(pair, "=", 2)
 		if len(kv) == 2 {

--- a/flagset_test.go
+++ b/flagset_test.go
@@ -560,12 +560,13 @@ func TestStringSlice(t *testing.T) {
 		"--no-default", "nd1",
 		"--no-default", "nd2",
 		"--no-default", "nd3,nd4",
+		"--no-default", "nd5\nnd6",
 		"--tag-default", "three",
 		"--tag-override", "three",
 	})
 	require.NoError(t, err)
 
-	assert.Equal(t, []string{"nd1", "nd2", "nd3", "nd4"}, config.NoDefault)
+	assert.Equal(t, []string{"nd1", "nd2", "nd3", "nd4", "nd5", "nd6"}, config.NoDefault)
 	assert.Equal(t, []string{"apple", "orange"}, config.InstanceDefault)
 	assert.Equal(t, []string{"one", "two", "three"}, config.TagDefault)
 	assert.Equal(t, []string{"three"}, config.TagOverride)
@@ -599,10 +600,14 @@ func TestStringToStringMap(t *testing.T) {
     	 \(default (veggie=carrot,fruit=apple|fruit=apple,veggie=carrot)\)
 `, buf.String())
 
-	err = flagset.Parse([]string{"--no-default", "k1=v1", "--no-default", "k2=v2,k3=v3"})
+	err = flagset.Parse([]string{"--no-default",
+		"k1=v1",
+		"--no-default",
+		"k2=v2,k3=v3\nk4=v4",
+	})
 	require.NoError(t, err)
 
-	assert.Equal(t, map[string]string{"k1": "v1", "k2": "v2", "k3": "v3"}, config.NoDefault)
+	assert.Equal(t, map[string]string{"k1": "v1", "k2": "v2", "k3": "v3", "k4": "v4"}, config.NoDefault)
 	assert.Equal(t, map[string]string{"fruit": "apple", "veggie": "carrot"}, config.TagDefault)
 }
 


### PR DESCRIPTION
Enables support for YAML block scalar literals in Docker/Kubernetes configs