### PR TITLE
Dereference default values before stringing

### DIFF
--- a/flagset_test.go
+++ b/flagset_test.go
@@ -5,6 +5,8 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"reflect"
+	"strconv"
 	"testing"
 	"time"
 
@@ -459,6 +461,32 @@ func TestDefaultsViaTag(t *testing.T) {
     	 (default "h1")
   -timeout duration
     	 (default 5s)
+`, buf.String())
+}
+
+func TestSimpleTypeDefaultsViaTag(t *testing.T) {
+	type Config struct {
+		Count int16 `default:"42"`
+	}
+
+	flagsfiller.RegisterSimpleType(func(s string, tag reflect.StructTag) (int16, error) {
+		i, err := strconv.ParseInt(s, 10, 16)
+		return int16(i), err
+	})
+
+	var config Config
+
+	filler := flagsfiller.New()
+
+	var flagset flag.FlagSet
+	err := filler.Fill(&flagset, &config)
+	require.NoError(t, err)
+
+	buf := grabUsage(flagset)
+
+	assert.Equal(t, `
+  -count value
+    	 (default 42)
 `, buf.String())
 }
 

--- a/simple.go
+++ b/simple.go
@@ -32,7 +32,7 @@ func (v *simpleType[T]) String() string {
 	if v.val == nil {
 		return fmt.Sprint(nil)
 	}
-	return fmt.Sprint(v.val)
+	return fmt.Sprint(*v.val)
 }
 
 func (v *simpleType[T]) StrConverter(s string) (T, error) {


### PR DESCRIPTION
When custom primitives implemented via `RegisterSimpleType` have a default value, the default appears as a pointer rather than a value (e.g. `(default 0x1400000ebee)`)