### PR TITLE
Improve type naming when using pflag

### DIFF
--- a/flagset.go
+++ b/flagset.go
@@ -667,6 +667,10 @@ func (s *strSliceVar) Set(val string) error {
 	return nil
 }
 
+func (s *strSliceVar) Type() string {
+	return getTypeName(reflect.TypeOf(s.ref))
+}
+
 func parseStringSlice(val string, valueSplitPattern string) []string {
 	if valueSplitPattern == "" {
 		return []string{val}
@@ -716,6 +720,10 @@ func (s strToStrMapVar) Set(val string) error {
 		s.val[k] = v
 	}
 	return nil
+}
+
+func (s strToStrMapVar) Type() string {
+	return getTypeName(reflect.TypeOf(s.val))
 }
 
 func parseStringToStringMap(val string) map[string]string {

--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSAS
 github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/simple.go
+++ b/simple.go
@@ -48,6 +48,10 @@ func (v *simpleType[T]) Set(s string) error {
 	return nil
 }
 
+func (v *simpleType[T]) Type() string {
+	return getTypeName(reflect.TypeOf(*new(T)))
+}
+
 func (v *simpleType[T]) SetRef(t *T) {
 	v.val = t
 }


### PR DESCRIPTION
When using `pflag`, which is required with `viper` or `cobra`, flag types show up like this, which looks very odd:
```
      --count simpleType[int16]             
      --enabled                 
      --hosts strSliceVar         
      --map strToStrMapVar 
      --timeout duration         (default 0s)
```

This PR implements `Type() string` for all custom types so that they show up as normal go types rather than flagfiller's wrapper types, which is [used by pflag](https://github.com/spf13/pflag/blob/master/flag.go#L600) to resolve the type name